### PR TITLE
feat: frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,37 @@ export interface ExcludePatterns {
   build: string | string[] // paths or globs
 }
 ```
+
+## Features:
+
+### Frontmatter support:
+
+Frontmatter yaml will be parsed according the following structure:
+
+```typescript
+export interface PageData {
+  title: string
+  description?: string
+  keywords?: string[]
+  imports?: string[]
+  meta?: Record<string, string>
+}
+```
+
+These attributes are then used to generate the following html snippets to be included in the output html, along with the transpiled markdown:
+
+#### `PageData.title: string`
+
+A value to use as the text content for a `<title>` in the rendered html's `<head>`.
+
+#### `PageData.description: string`
+
+A value to use as the text content for a `<meta name="description" content=${description} />` in the rendered html's `<head>`.
+
+#### `PageData.keywords: string[]`
+
+A value to use as the text content for a `<meta name="keywords" content=${keywords} />` in the rendered html's `<head>`.
+
+#### `PageData.meta: Record<string, string>`
+
+A mapping of key value pairs to use for creating arbitrary`<meta name=${key} content=${value} />` in the rendered html's `<head>`.

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8,12 +8,38 @@
       "name": "static-markdown-example",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "vite-plugin-static-md": "file:.."
+      },
       "devDependencies": {
         "@types/jsdom": "^21.1.7",
         "@types/node": "^22.9.0",
         "prettier": "^3.3.3",
         "typescript": "^5.6.3",
         "vite": "^5.4.9"
+      }
+    },
+    "..": {
+      "name": "vite-plugin-static-md",
+      "version": "0.2.5",
+      "license": "MIT",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "jsdom": "^25.0.1",
+        "marked": "^15.0.1",
+        "vite": "^5.4.11",
+        "yaml": "^2.6.0"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^19.5.0",
+        "@commitlint/config-conventional": "^19.5.0",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "^22.9.0",
+        "commit-and-tag-version": "^12.5.0",
+        "husky": "^9.1.6",
+        "prettier": "^3.3.3",
+        "standard-version": "^9.5.0",
+        "typescript": "^5.6.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -916,6 +942,10 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-plugin-static-md": {
+      "resolved": "..",
+      "link": true
     }
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -13,6 +13,9 @@
   "prettier": {
     "semi": false
   },
+  "dependencies": {
+    "vite-plugin-static-md": "file:.."
+  },
   "devDependencies": {
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.9.0",

--- a/example/src/pages/index.md
+++ b/example/src/pages/index.md
@@ -1,3 +1,8 @@
+---
+title: Example Index Page
+description: An index linking to a few other pages
+---
+
 - [excluded-always (this link should be dead always)/](./excluded-always/)
 - [excluded-prod (this link should be dead only in prod build)/](./excluded-prod/)
 - [other/](./other/)

--- a/example/src/pages/page/index.md
+++ b/example/src/pages/page/index.md
@@ -1,3 +1,11 @@
+---
+description: An example using some meta tags too
+meta:
+  foo: bar
+  key: value
+  num: 1
+---
+
 # page/index.md
 
 This is the index for `./page/`.

--- a/example/src/pages/page/nested.md
+++ b/example/src/pages/page/nested.md
@@ -1,3 +1,7 @@
+---
+keywords: [test, more, another, "multi word tag"]
+---
+
 # page/nested.md
 
 This is a nested page that should be at `./page/nested/`.

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -1,7 +1,7 @@
 import { resolve } from "path"
 import type { UserConfig } from "vite"
 
-import staticMd from "../src/main"
+import staticMd from "vite-plugin-static-md"
 
 const OUT_DIR = resolve(__dirname, "dist")
 const HTML_ROOT = resolve(__dirname, "src/pages")

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
+        "gray-matter": "^4.0.3",
         "jsdom": "^25.0.1",
         "marked": "^15.0.1",
-        "vite": "^5.4.11"
+        "vite": "^5.4.11",
+        "yaml": "^2.6.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.5.0",
@@ -3045,6 +3047,29 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3492,6 +3517,40 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -3696,6 +3755,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3865,7 +3932,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4636,6 +4702,18 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -4717,6 +4795,11 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/standard-version": {
       "version": "9.5.0",
@@ -4970,6 +5053,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-indent": {
@@ -5363,7 +5454,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
       "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
-      "dev": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -32,15 +32,17 @@
     ]
   },
   "dependencies": {
+    "gray-matter": "^4.0.3",
     "jsdom": "^25.0.1",
     "marked": "^15.0.1",
-    "vite": "^5.4.11"
+    "vite": "^5.4.11",
+    "yaml": "^2.6.0"
   },
   "devDependencies": {
-    "@types/jsdom": "^21.1.7",
-    "@types/node": "^22.9.0",
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
+    "@types/jsdom": "^21.1.7",
+    "@types/node": "^22.9.0",
     "commit-and-tag-version": "^12.5.0",
     "husky": "^9.1.6",
     "prettier": "^3.3.3",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { glob } from "fs/promises"
 import { parse, resolve } from "path"
-import { UserConfig } from "vite"
+import type { UserConfig } from "vite"
 
 import { Context, Mode, completeContext, initContext } from "./context.js"
 import {
@@ -24,7 +24,7 @@ export async function modifyConfig(
 
   // setup logger if not vite's default
   if (userConfig.logLevel) {
-    logger = replaceLogger(userConfig.logLevel)
+    logger = replaceLogger("info")
   }
 
   // get web root dir from config
@@ -34,7 +34,7 @@ export async function modifyConfig(
   logger.info("excludes list expanded to:")
   logger.dir(exclude_list)
   const paths = await getPaths(root, exclude_list)
-  const pages = await getPages(paths, root, ictx.mode)
+  const pages = await getPages(paths, root, ictx)
   logger.dir(pages)
 
   const cfg = {

--- a/src/devServer.ts
+++ b/src/devServer.ts
@@ -13,13 +13,14 @@
 import { Connect, PreviewServer, ViteDevServer, send } from "vite"
 
 import { Context } from "./context.js"
-import { mdToDynHtml } from "./html.js"
+import { renderDyn } from "./html.js"
 import { logger } from "./logging.js"
+import { PageData } from "./page.js"
 
 // emit files to the bundle probably
-export function indexMdMiddleware(
+export function indexMdMiddleware<Data extends PageData>(
   server: ViteDevServer | PreviewServer,
-  { root, pages, htmlTemplate, cssFile }: Context,
+  { root, pages, htmlTemplate, cssFile }: Context<Data>,
 ): Connect.NextHandleFunction {
   const isDev = isDevServer(server)
 
@@ -36,8 +37,8 @@ export function indexMdMiddleware(
     ) {
       logger().info(`handling ${url}`)
       // get the source id from the page url path
-      let { src } = pages[url]
-      logger().info(`matched ${src}`)
+      let page = pages[url]
+      logger().info(`matched ${page.src}`)
 
       // then the rest here gets changed to simply get the same headers
       const headers = isDev
@@ -49,7 +50,7 @@ export function indexMdMiddleware(
         // `<filename>.md?raw`, parses it w/ marked before inserting parsed
         // markdown into html template instead of loading from filesystem
         if (isDev) {
-          let html = await mdToDynHtml(src, root, htmlTemplate, cssFile)
+          let html = await renderDyn(page, root, htmlTemplate, cssFile)
           // have vite apply standard html transforms
           // (hopefully this includes adding the markdown source to the module graph?)
           logger().info(`${url} before vite's transform:`)

--- a/src/html.ts
+++ b/src/html.ts
@@ -3,9 +3,14 @@ import { marked } from "marked"
 import { parse } from "path"
 
 import { getInputRelativePath } from "./path.js"
+import { Page, PageData } from "./page.js"
+import { logger } from "./logging.js"
 
-export async function mdToStaticHtml(
-  md: string,
+/**
+ * render markdown source file to static html
+ */
+export async function renderStatic(
+  { md, data }: Page,
   htmlTemplate: string,
   cssFile?: string,
 ): Promise<string> {
@@ -13,7 +18,7 @@ export async function mdToStaticHtml(
   const asHtml = await marked(md)
   // create mock dom for html manipulation
   const document = createDocument(htmlTemplate, cssFile)
-  // find target node for markdown content
+  // get target node for markdown content insertion
   const targetNode = document.querySelector("#markdown-target")
   if (targetNode == null) {
     throw TypeError(
@@ -30,29 +35,151 @@ export async function mdToStaticHtml(
   targetNode.innerHTML = asHtml
   body.appendChild(scriptTag)
 
+  // get head node for frontmatter metadata insertion
+  const head = document.querySelector("head") || document.createElement("head")
+  const tags = buildHeadTags(document, data)
+  for (const tag of tags) {
+    head.appendChild(tag)
+  }
+
   return normalizeHtml(document.documentElement.outerHTML)
 }
 
-export async function mdToDynHtml(
-  mdSrcPath: string,
+/**
+ * build `<head ... />` from `PageData`
+ */
+export function buildHeadTags(doc: Document, data: PageData): HTMLElement[] {
+  let tags: HTMLElement[] = []
+  // build head tags & append them
+  // title
+  const title = doc.createElement("title")
+  title.textContent = data.title
+  tags.push(title)
+
+  // description => meta.name="{description}"
+  if (data.description) {
+    const desc = doc.createElement("meta")
+    desc.name = "description"
+    desc.content = data.description
+    tags.push(desc)
+  }
+
+  // all other meta[name]: value => meta.name="{value}"
+  if (data.meta) {
+    let el: HTMLMetaElement
+    for (const prop in data.meta) {
+      el = doc.createElement("meta")
+      el.name = prop
+      el.content = data.meta[prop]
+      tags.push(el)
+    }
+  }
+
+  // keywords => meta.name="{keywords}"
+  if (data.keywords && data.keywords.length !== 0) {
+    const kw = doc.createElement("meta")
+    kw.name = "keywords"
+    kw.content = data.keywords.join(", ")
+    tags.push(kw)
+  }
+
+  return tags
+}
+
+/**
+ * render markdown source file to dynamic html w/ inline script suitable for HMR
+ */
+export async function renderDyn(
+  page: Page,
   root: string,
   htmlTemplate: string,
   cssFile?: string,
 ): Promise<string> {
+  const { src } = page
+  logger().info(`building dynamic html for ${src}`)
+  logger().dir(page)
   const document = createDocument(htmlTemplate, cssFile)
   const body = document.querySelector("body")!
 
-  const mdSrcRelative = getInputRelativePath(parse(mdSrcPath), root)
+  const mdSrcRelative = getInputRelativePath(parse(src), root)
 
   const scriptTag = document.createElement("script")
   scriptTag.type = "module"
   scriptTag.text = `
 import { marked } from "marked"
+import { parse } from "yaml"
 
 import doc from "/${mdSrcRelative}?raw"
 
-const content = marked.parse(doc)
-document.querySelector("#markdown-target").innerHTML = content
+const lines = doc.split(/\\r?\\n/)
+const fence = "---"
+const dataLines = []
+let idx = 1
+if ( lines[0] === fence) {
+  while (lines[idx] !== fence) {
+    dataLines.push(lines[idx])
+    idx++
+  }
+}
+const data = dataLines.length !== 0 ? parse(dataLines.join("\\n")) : {}
+// page title defaults to filename
+if (!data.title) {
+  data.title = "${mdSrcRelative}"
+}
+// FIXME: this doesn't work in build
+document.pageData = data
+console.log("frontmatter parsed & added to Document:")
+console.dir(document.pageData)
+const content = lines.slice(idx+1).join("\\n")
+console.log("content:", content)
+
+let head = document.querySelector("head")
+if (!!!head) {
+  head = document.createElement("head")
+  document.querySelector('html').prepend(head)
+}
+let headTags = []
+
+const title = document.createElement("title")
+title.textContent = data.title
+headTags.push(title)
+
+// description => meta.description
+if (data.description) {
+  const desc = document.createElement("meta")
+  desc.name = "description"
+  desc.content = data.description
+  headTags.push(desc)
+}
+
+// all other meta[name]: value => meta.name="value"
+if (data.meta) {
+  let el
+  for (const prop in data.meta) {
+    el = document.createElement("meta")
+    el.name = prop
+    el.content = data.meta[prop]
+    headTags.push(el)
+  }
+}
+
+// keywords => meta.name="{keywords}"
+if (data.keywords && data.keywords.length !== 0) {
+  const kw = document.createElement("meta")
+  kw.name = "keywords"
+  kw.content = data.keywords.join(", ")
+  headTags.push(kw)
+}
+
+// add head tags from frontmatter
+for (const tag of headTags) {
+  head.appendChild(tag)
+}
+
+// add markdown to body
+const target = document.querySelector("#markdown-target")
+const html = marked.parse(content)
+target.innerHTML = html
   `
 
   body.appendChild(scriptTag)
@@ -60,7 +187,9 @@ document.querySelector("#markdown-target").innerHTML = content
   return normalizeHtml(document.documentElement.outerHTML)
 }
 
-// alter given string so it has everything needed to be a complete html doc
+/**
+ * alter given string so it has everything needed to be a complete html doc
+ */
 function normalizeHtml(code: string): string {
   const doctype = "<!doctype html>"
 
@@ -75,6 +204,10 @@ function normalizeHtml(code: string): string {
   return res
 }
 
+/**
+ * create an html document object from a given html string, adding a stylesheet
+ * link tag if css file is given
+ */
 function createDocument(htmlTemplate: string, cssFile?: string): Document {
   const DOM = new JSDOM(htmlTemplate)
   const document = DOM.window.document

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,8 +1,5 @@
-import {
-  LogLevel,
-  Logger as ViteLogger,
-  createLogger as createViteLogger,
-} from "vite"
+import type { LogLevel, Logger as ViteLogger } from "vite"
+import { createLogger as createViteLogger } from "vite"
 import { dir } from "./utils.js"
 
 let _logger: ExtendedLogger
@@ -36,16 +33,3 @@ export function replace(level?: LogLevel): ExtendedLogger {
 
   return _logger
 }
-
-// class Logger {
-//   static #instance: Logger
-//   viteLogger: ViteLogger
-//
-//   private constructor(level?: LogLevel) {
-//     this.viteLogger = createViteLogger(level ?? "warn")
-//   }
-//
-//   public static get instance(): Logger {
-//
-//   }
-// }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,77 @@
+import type { Plugin, UserConfig } from "vite"
+
+import { modifyConfig } from "./config.js"
+import { indexMdMiddleware } from "./devServer.js"
+import { renderStatic } from "./html.js"
+import { ctx, setCtx } from "./provider.js"
+
+export interface Options {
+  cssFile?: string // exact path only
+  excludes?: string | string[] | ExcludePatterns // paths or globs
+  htmlTemplate?: string // exact path only
+}
+
+export interface ExcludePatterns {
+  serve?: string | string[] // paths or globs
+  build: string | string[] // paths or globs
+}
+
+export function plugin(opts?: Options): Plugin[] {
+  return [
+    {
+      name: "static-md-plugin:serve",
+      apply: "serve",
+
+      // setup log level if user provides a value
+      async config(userConfig): Promise<UserConfig> {
+        const [builtContext, cfg] = await modifyConfig(userConfig, opts)
+        setCtx(builtContext)
+
+        return cfg
+      },
+
+      // configure custom middleware to point urls matching `pages` to their
+      // markdown sources & transform those sources into index.html files
+      configureServer(server) {
+        server.middlewares.use(indexMdMiddleware(server, ctx()))
+      },
+    },
+    {
+      name: "static-md-plugin:build",
+      apply: "build",
+
+      // edit user config to add all markdown files as rollup entry points
+      async config(userConfig): Promise<UserConfig> {
+        const [builtContext, cfg] = await modifyConfig(
+          userConfig,
+          opts,
+          "build",
+        )
+        setCtx(builtContext)
+
+        return cfg
+      },
+
+      resolveId(src: string) {
+        // sources not in pages map are skipped
+        if (!ctx().filter(src)) return null
+        // ensure sources given in pages map are resolved,
+        // even if the file doesn't exist
+        return src
+      },
+
+      async load(id: string) {
+        let _ctx = ctx()
+        // ids not in pages map are skipped
+        if (!_ctx.filter(id)) return null
+
+        const page = _ctx.pages[id]
+        const res = {
+          code: await renderStatic(page, _ctx.htmlTemplate, _ctx.cssFile),
+        }
+
+        return res
+      },
+    },
+  ]
+}


### PR DESCRIPTION
Adds frontmatter support for markdown sources. Data included in frontmatter is used to build a more informative `<head>` in the output html.